### PR TITLE
fix: defer SeoService injections to prevent hydration errors

### DIFF
--- a/src/app/pages/about.component.ts
+++ b/src/app/pages/about.component.ts
@@ -1,7 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SeoService } from '../shared/seo.service';
-import { inject, OnInit } from '@angular/core';
 
 @Component({
   standalone: true,
@@ -10,16 +9,14 @@ import { inject, OnInit } from '@angular/core';
   imports: [CommonModule]
 })
 export class AboutComponent implements OnInit {
-  
-
-  seo: any;
-
   ngOnInit() {
-  this.seo = inject(SeoService);
-    this.seo.update({
-      title: 'About Amruth Royal Cuisine',
-      description: 'Our story and passion for authentic Indian cuisine.',
-      url: 'https://amruth.example/about'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'About Amruth Royal Cuisine',
+        description: 'Our story and passion for authentic Indian cuisine.',
+        url: 'https://amruth.example/about'
+      });
+    }
   }
 }

--- a/src/app/pages/blog.component.ts
+++ b/src/app/pages/blog.component.ts
@@ -12,14 +12,16 @@ import { RouterLink } from '@angular/router';
 })
 export class BlogComponent implements OnInit {
   private sanity = inject(SanityService);
-  private seo = inject(SeoService);
   posts = this.sanity.fetchPosts();
 
   ngOnInit() {
-    this.seo.update({
-      title: 'Blog – Amruth Royal Cuisine',
-      description: 'News and recipes from our kitchen.',
-      url: 'https://amruth.example/blog'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'Blog – Amruth Royal Cuisine',
+        description: 'News and recipes from our kitchen.',
+        url: 'https://amruth.example/blog'
+      });
+    }
   }
 }

--- a/src/app/pages/contact.component.ts
+++ b/src/app/pages/contact.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { SeoService } from '../shared/seo.service';
@@ -9,7 +9,7 @@ import { SeoService } from '../shared/seo.service';
   templateUrl: './contact.component.html',
   imports: [CommonModule, ReactiveFormsModule]
 })
-export class ContactComponent {
+export class ContactComponent implements OnInit {
   private fb = new FormBuilder();
   sent = false;
 
@@ -20,12 +20,15 @@ export class ContactComponent {
     website: ['']
   });
 
-  constructor(private seo: SeoService) {
-    this.seo.update({
-      title: 'Contact Amruth Royal Cuisine',
-      description: 'Get in touch with our team for reservations and inquiries.',
-      url: 'https://amruth.example/contact'
-    });
+  ngOnInit() {
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'Contact Amruth Royal Cuisine',
+        description: 'Get in touch with our team for reservations and inquiries.',
+        url: 'https://amruth.example/contact'
+      });
+    }
   }
 
   async submit() {

--- a/src/app/pages/faqs.component.ts
+++ b/src/app/pages/faqs.component.ts
@@ -11,13 +11,15 @@ import { SeoService } from '../shared/seo.service';
 })
 export class FaqsComponent implements OnInit {
   items = faqs;
-  private seo = inject(SeoService);
 
   ngOnInit() {
-    this.seo.update({
-      title: 'FAQs – Amruth Royal Cuisine',
-      description: 'Frequently asked questions about our restaurant.',
-      url: 'https://amruth.example/faqs'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'FAQs – Amruth Royal Cuisine',
+        description: 'Frequently asked questions about our restaurant.',
+        url: 'https://amruth.example/faqs'
+      });
+    }
   }
 }

--- a/src/app/pages/home.component.ts
+++ b/src/app/pages/home.component.ts
@@ -13,7 +13,6 @@ import { CtaComponent } from '../components/cta.component';
   imports: [CommonModule, HeroComponent, MenuCardComponent, CtaComponent]
 })
 export class HomeComponent implements OnInit {
-  private seo = inject(SeoService);
   private sanity = inject(SanityService);
 
   featured: MenuItem[] = [];
@@ -21,10 +20,13 @@ export class HomeComponent implements OnInit {
 
   async ngOnInit() {
     this.featured = await this.sanity.fetchFeaturedMenu();
-    this.seo.update({
-      title: 'Amruth Royal Cuisine – Authentic Indian Food in Wixom, MI',
-      description: 'Savor royal Indian flavors. Dine-in, takeout, catering.',
-      url: 'https://amruth.example/'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'Amruth Royal Cuisine – Authentic Indian Food in Wixom, MI',
+        description: 'Savor royal Indian flavors. Dine-in, takeout, catering.',
+        url: 'https://amruth.example/'
+      });
+    }
   }
 }

--- a/src/app/pages/legal.component.ts
+++ b/src/app/pages/legal.component.ts
@@ -1,7 +1,5 @@
-import { Component, OnInit, inject } from '@angular/core';
-import { Injector,PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
-import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { SeoService } from '../shared/seo.service';
 
 @Component({
@@ -12,11 +10,10 @@ import { SeoService } from '../shared/seo.service';
 })
 export class LegalComponent implements OnInit {
   sections: { title: string; content: string }[] = [];
-  
+
   async ngOnInit() {
-  const seo = inject(SeoService);
-  const platformId = inject(Injector).get(PLATFORM_ID)
-    if (isPlatformBrowser(platformId)) {
+    if (isPlatformBrowser(inject(PLATFORM_ID))) {
+      const seo = inject(SeoService);
       const [privacy, tos] = await Promise.all([
         fetch('/data/legal/privacy.md').then(r => r.text()),
         fetch('/data/legal/tos.md').then(r => r.text())
@@ -25,11 +22,11 @@ export class LegalComponent implements OnInit {
         { title: 'Privacy Policy', content: privacy },
         { title: 'Terms of Service', content: tos }
       ];
+      seo.update({
+        title: 'Legal – Amruth Royal Cuisine',
+        description: 'Our privacy policy and terms of service.',
+        url: 'https://amruth.example/legal'
+      });
     }
-    seo.update({
-      title: 'Legal – Amruth Royal Cuisine',
-      description: 'Our privacy policy and terms of service.',
-      url: 'https://amruth.example/legal'
-    });
   }
 }

--- a/src/app/pages/locations.component.ts
+++ b/src/app/pages/locations.component.ts
@@ -9,13 +9,14 @@ import { SeoService } from '../shared/seo.service';
   imports: [CommonModule]
 })
 export class LocationsComponent implements OnInit {
-  private seo = inject(SeoService);
-
   ngOnInit() {
-    this.seo.update({
-      title: 'Locations – Amruth Royal Cuisine',
-      description: 'Visit us in Wixom, MI.',
-      url: 'https://amruth.example/locations'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'Locations – Amruth Royal Cuisine',
+        description: 'Visit us in Wixom, MI.',
+        url: 'https://amruth.example/locations'
+      });
+    }
   }
 }

--- a/src/app/pages/menu.component.ts
+++ b/src/app/pages/menu.component.ts
@@ -12,16 +12,18 @@ import { MenuCardComponent } from '../components/menu-card.component';
 })
 export class MenuComponent implements OnInit {
   private sanity = inject(SanityService);
-  private seo = inject(SeoService);
 
   categories: { title: string; items: MenuItem[] }[] = [];
 
   async ngOnInit() {
     this.categories = await this.sanity.fetchMenu();
-    this.seo.update({
-      title: 'Menu – Amruth Royal Cuisine',
-      description: 'Explore our menu of starters, curries, biryani and more.',
-      url: 'https://amruth.example/menu'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'Menu – Amruth Royal Cuisine',
+        description: 'Explore our menu of starters, curries, biryani and more.',
+        url: 'https://amruth.example/menu'
+      });
+    }
   }
 }

--- a/src/app/pages/post.component.ts
+++ b/src/app/pages/post.component.ts
@@ -13,14 +13,14 @@ import { SeoService } from '../shared/seo.service';
 export class PostComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private sanity = inject(SanityService);
-  private seo = inject(SeoService);
   post?: Post;
 
   async ngOnInit() {
     const slug = this.route.snapshot.paramMap.get('slug')!;
     this.post = await this.sanity.fetchPost(slug);
-    if (this.post) {
-      this.seo.update({
+    if (this.post && typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
         title: this.post.title,
         description: this.post.excerpt,
         url: `https://amruth.example/blog/${slug}`

--- a/src/app/pages/testimonials.component.ts
+++ b/src/app/pages/testimonials.component.ts
@@ -11,14 +11,16 @@ import { SeoService } from '../shared/seo.service';
 })
 export class TestimonialsComponent implements OnInit {
   private sanity = inject(SanityService);
-  private seo = inject(SeoService);
   testimonials = this.sanity.fetchTestimonials();
 
   ngOnInit() {
-    this.seo.update({
-      title: 'Testimonials – Amruth Royal Cuisine',
-      description: 'Hear from our guests.',
-      url: 'https://amruth.example/testimonials'
-    });
+    if (typeof window !== 'undefined') {
+      const seo = inject(SeoService);
+      seo.update({
+        title: 'Testimonials – Amruth Royal Cuisine',
+        description: 'Hear from our guests.',
+        url: 'https://amruth.example/testimonials'
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- move SeoService and PLATFORM_ID injections into `ngOnInit` guarded by browser checks to avoid NG0908 hydration errors
- replace constructor and property injections with conditional `inject` calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad78a3348331ad3a9e85208e5441